### PR TITLE
remove pytest.warns(None)

### DIFF
--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -2444,19 +2444,15 @@ async def test_drop_auth_on_redirect_to_other_host(
 
 
 async def test_async_with_session() -> None:
-    with pytest.warns(None) as cm:
-        async with aiohttp.ClientSession() as session:
-            pass
-    assert len(cm.list) == 0
+    async with aiohttp.ClientSession() as session:
+        pass
 
     assert session.closed
 
 
 async def test_session_close_awaitable() -> None:
     session = aiohttp.ClientSession()
-    with pytest.warns(None) as cm:
-        await session.close()
-    assert len(cm.list) == 0
+    await session.close()
 
     assert session.closed
 
@@ -2464,10 +2460,7 @@ async def test_session_close_awaitable() -> None:
 async def test_close_run_until_complete_not_deprecated() -> None:
     session = aiohttp.ClientSession()
 
-    with pytest.warns(None) as cm:
-        await session.close()
-
-    assert len(cm.list) == 0
+    await session.close()
 
 
 async def test_close_resp_on_error_async_with_session(aiohttp_server: Any) -> None:

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -2457,12 +2457,6 @@ async def test_session_close_awaitable() -> None:
     assert session.closed
 
 
-async def test_close_run_until_complete_not_deprecated() -> None:
-    session = aiohttp.ClientSession()
-
-    await session.close()
-
-
 async def test_close_resp_on_error_async_with_session(aiohttp_server: Any) -> None:
     async def handler(request):
         resp = web.StreamResponse(headers={"content-length": "100"})


### PR DESCRIPTION
## What do these changes do?

Fix a deprecated misuse of pytest.warns()

https://docs.pytest.org/en/latest/deprecations.html#using-pytest-warns-none

Since the test suire errors on any unfiltered warning anyway, these context manageres are not necessary.

## Are there changes in behavior for the user?

No. Just the test suite

## Related issue number

#6663

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
